### PR TITLE
fix: Porting Lib compatibility issue

### DIFF
--- a/cobblegen-1.18.2-compat/build.gradle
+++ b/cobblegen-1.18.2-compat/build.gradle
@@ -7,7 +7,8 @@ dependencies {
 
     modLocalRuntime("net.fabricmc.fabric-api:fabric-api:${project.fabric_version_1_18_2}")
 
-    modLocalRuntime("com.simibubi.create:create-fabric-${project.minecraft_version_1_18_2}:${project.create_version_1_18_2}")
+    if (project.run_with_create.toLowerCase(Locale.ROOT) == "yes")
+        modLocalRuntime("com.simibubi.create:create-fabric-${project.minecraft_version_1_18_2}:${project.create_version_1_18_2}")
     switch (project.recipe_viewer.toLowerCase(Locale.ROOT)) {
         case "rei": modLocalRuntime("me.shedaniel:RoughlyEnoughItems-fabric:$project.rei_version_1_18_2"); break
         case "emi": modLocalRuntime("dev.emi:emi:${project.emi_version}+${project.minecraft_version_1_18_2}"); break

--- a/cobblegen-1.19-compat/build.gradle
+++ b/cobblegen-1.19-compat/build.gradle
@@ -7,7 +7,8 @@ dependencies {
 
     modLocalRuntime("net.fabricmc.fabric-api:fabric-api:${project.fabric_version_1_19_2}")
 
-    modLocalRuntime("com.simibubi.create:create-fabric-${project.minecraft_version_1_19_2}:${project.create_version_1_19_2}")
+    if (project.run_with_create.toLowerCase(Locale.ROOT) == "yes")
+        modLocalRuntime("com.simibubi.create:create-fabric-${project.minecraft_version_1_19_2}:${project.create_version_1_19_2}")
     switch (project.recipe_viewer.toLowerCase(Locale.ROOT)) {
         case "rei": {
             modLocalRuntime("dev.architectury:architectury-fabric:${project.architectury_version_1_19_2}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,6 +30,7 @@ yarn_mappings_1_19_3=1.19.3+build.5
 fabric_version_1_19_3=0.76.0+1.19.3
 
 # Runtime Properties
+run_with_create=no
 recipe_viewer=rei
 
 # Dependencies

--- a/src/main/java/io/github/null2264/cobblegen/CobbleGen.java
+++ b/src/main/java/io/github/null2264/cobblegen/CobbleGen.java
@@ -1,5 +1,6 @@
 package io.github.null2264.cobblegen;
 
+import io.github.null2264.cobblegen.compat.porting_lib.FluidInteractionEvent;
 import io.github.null2264.cobblegen.config.ConfigHelper;
 import io.github.null2264.cobblegen.util.Compat;
 import net.fabricmc.api.ModInitializer;
@@ -22,5 +23,9 @@ public class CobbleGen implements ModInitializer
     public void onInitialize() {
         LOGGER.info("Loading config...");
         ConfigHelper.loadAndSaveDefault();
+        if (FabricLoader.getInstance().isModLoaded("porting_lib")) {
+            LOGGER.info("Porting Lib is found, registering event...");
+            FluidInteractionEvent.register();
+        }
     }
 }

--- a/src/main/java/io/github/null2264/cobblegen/compat/porting_lib/FluidInteractionEvent.java
+++ b/src/main/java/io/github/null2264/cobblegen/compat/porting_lib/FluidInteractionEvent.java
@@ -38,19 +38,17 @@ public class FluidInteractionEvent
             if (direction == Direction.UP) continue;
 
             FluidState metFluidState = fluidState.isStill() ? fluidState : world.getFluidState(pos.offset(direction));
-            if (metFluidState.isIn(FluidTags.WATER)) {
+            BlockPos blockPos = pos.offset(direction.getOpposite());
+            if (metFluidState.getFluid() instanceof WaterFluid) {
                 val generator = new BlockGenerator(
                         (World) world,
                         pos,
                         GeneratorType.COBBLE
                 );
                 return generator.getReplacement();
-            } else {
-                BlockPos blockPos = pos.offset(direction.getOpposite());
-                if (world.getBlockState(blockPos).isOf(Blocks.BLUE_ICE)) {
-                    val generator = new BlockGenerator((World) world, pos, GeneratorType.BASALT);
-                    return generator.getReplacement();
-                }
+            } else if (world.getBlockState(blockPos).isOf(Blocks.BLUE_ICE)) {
+                val generator = new BlockGenerator((World) world, pos, GeneratorType.BASALT);
+                return generator.getReplacement();
             }
         }
         return null;

--- a/src/main/java/io/github/null2264/cobblegen/compat/porting_lib/FluidInteractionEvent.java
+++ b/src/main/java/io/github/null2264/cobblegen/compat/porting_lib/FluidInteractionEvent.java
@@ -6,6 +6,7 @@ import io.github.null2264.cobblegen.util.GeneratorType;
 import lombok.val;
 import net.minecraft.block.BlockState;
 import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.Fluids;
 import net.minecraft.fluid.LavaFluid;
 import net.minecraft.fluid.WaterFluid;
 import net.minecraft.tag.FluidTags;
@@ -20,7 +21,7 @@ public class FluidInteractionEvent
 {
     public static BlockState whenFluidsMeet(WorldAccess world, BlockPos pos, BlockState state) {
         FluidState fluidState = state.getFluidState();
-        if (fluidState.isEmpty()) return null;
+        if (fluidState.isEmpty() || (fluidState.isStill() && fluidState.isOf(Fluids.LAVA))) return null;
 
         FluidState fluidStateAbove = world.getFluidState(pos.up());
         if (fluidState.getFluid() instanceof WaterFluid && fluidStateAbove.getFluid() instanceof LavaFluid) {

--- a/src/main/java/io/github/null2264/cobblegen/compat/porting_lib/FluidInteractionEvent.java
+++ b/src/main/java/io/github/null2264/cobblegen/compat/porting_lib/FluidInteractionEvent.java
@@ -5,6 +5,7 @@ import io.github.null2264.cobblegen.util.BlockGenerator;
 import io.github.null2264.cobblegen.util.GeneratorType;
 import lombok.val;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.fluid.LavaFluid;
@@ -37,14 +38,20 @@ public class FluidInteractionEvent
             if (direction == Direction.UP) continue;
 
             FluidState metFluidState = fluidState.isStill() ? fluidState : world.getFluidState(pos.offset(direction));
-            if (!metFluidState.isIn(FluidTags.WATER)) continue;
-
-            val generator = new BlockGenerator(
-                    (World) world,
-                    pos,
-                    GeneratorType.COBBLE
-            );
-            return generator.getReplacement();
+            if (metFluidState.isIn(FluidTags.WATER)) {
+                val generator = new BlockGenerator(
+                        (World) world,
+                        pos,
+                        GeneratorType.COBBLE
+                );
+                return generator.getReplacement();
+            } else {
+                BlockPos blockPos = pos.offset(direction.getOpposite());
+                if (world.getBlockState(blockPos).isOf(Blocks.BLUE_ICE)) {
+                    val generator = new BlockGenerator((World) world, pos, GeneratorType.BASALT);
+                    return generator.getReplacement();
+                }
+            }
         }
         return null;
     }

--- a/src/main/java/io/github/null2264/cobblegen/compat/porting_lib/FluidInteractionEvent.java
+++ b/src/main/java/io/github/null2264/cobblegen/compat/porting_lib/FluidInteractionEvent.java
@@ -10,7 +10,6 @@ import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.fluid.LavaFluid;
 import net.minecraft.fluid.WaterFluid;
-import net.minecraft.tag.FluidTags;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
@@ -56,5 +55,9 @@ public class FluidInteractionEvent
 
     public static void register() {
         FluidPlaceBlockCallback.EVENT.register(FluidInteractionEvent::whenFluidsMeet);
+    }
+
+    public static BlockState invoke(WorldAccess world, BlockPos pos, BlockState state) {
+        return FluidPlaceBlockCallback.EVENT.invoker().onFluidPlaceBlock(world, pos, state);
     }
 }

--- a/src/main/java/io/github/null2264/cobblegen/compat/porting_lib/FluidInteractionEvent.java
+++ b/src/main/java/io/github/null2264/cobblegen/compat/porting_lib/FluidInteractionEvent.java
@@ -1,0 +1,54 @@
+package io.github.null2264.cobblegen.compat.porting_lib;
+
+import io.github.fabricators_of_create.porting_lib.event.common.FluidPlaceBlockCallback;
+import io.github.null2264.cobblegen.util.BlockGenerator;
+import io.github.null2264.cobblegen.util.GeneratorType;
+import lombok.val;
+import net.minecraft.block.BlockState;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.LavaFluid;
+import net.minecraft.fluid.WaterFluid;
+import net.minecraft.tag.FluidTags;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
+
+import static net.minecraft.client.render.WorldRenderer.DIRECTIONS;
+
+public class FluidInteractionEvent
+{
+    public static BlockState whenFluidsMeet(WorldAccess world, BlockPos pos, BlockState state) {
+        FluidState fluidState = state.getFluidState();
+        if (fluidState.isEmpty()) return null;
+
+        FluidState fluidStateAbove = world.getFluidState(pos.up());
+        if (fluidState.getFluid() instanceof WaterFluid && fluidStateAbove.getFluid() instanceof LavaFluid) {
+            val generator = new BlockGenerator(
+                    (World) world,
+                    pos,
+                    GeneratorType.STONE
+            );
+            return generator.getReplacement();
+        }
+
+        for (Direction direction : DIRECTIONS) {
+            if (direction == Direction.UP) continue;
+
+            FluidState metFluidState = fluidState.isStill() ? fluidState : world.getFluidState(pos.offset(direction));
+            if (!metFluidState.isIn(FluidTags.WATER)) continue;
+
+            val generator = new BlockGenerator(
+                    (World) world,
+                    pos,
+                    GeneratorType.COBBLE
+            );
+            return generator.getReplacement();
+        }
+        return null;
+    }
+
+    public static void register() {
+        FluidPlaceBlockCallback.EVENT.register(FluidInteractionEvent::whenFluidsMeet);
+    }
+}

--- a/src/main/java/io/github/null2264/cobblegen/mixin/CreateFluidReactionsMixin.java
+++ b/src/main/java/io/github/null2264/cobblegen/mixin/CreateFluidReactionsMixin.java
@@ -21,14 +21,13 @@ public abstract class CreateFluidReactionsMixin
 {
     private static void handleReaction(@NotNull Args args, World world, BlockPos pos) {
         BlockState state = args.get(1);
-        if (!state.getFluidState().isEmpty()) return;
-        if (state.isOf(Blocks.OBSIDIAN)) return;
-        BlockGenerator generator = new BlockGenerator(world,
-                                                      pos,
-                                                      state.isOf(Blocks.STONE) ? GeneratorType.STONE
-                                                                               : GeneratorType.COBBLE
-        );
-        generator.tryReplace(args);
+        if (state.isOf(Blocks.STONE) || state.isOf(Blocks.COBBLESTONE)) {
+            BlockGenerator generator = new BlockGenerator(world,
+                                                          pos,
+                                                          state.isOf(Blocks.STONE) ? GeneratorType.STONE : GeneratorType.COBBLE
+            );
+            generator.tryReplace(args);
+        }
     }
 
     @ModifyArgs(method = "handlePipeFlowCollision(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lio/github/fabricators_of_create/porting_lib/util/FluidStack;Lio/github/fabricators_of_create/porting_lib/util/FluidStack;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;)Z"))

--- a/src/main/java/io/github/null2264/cobblegen/mixin/FluidEventMixin.java
+++ b/src/main/java/io/github/null2264/cobblegen/mixin/FluidEventMixin.java
@@ -62,6 +62,9 @@ public abstract class FluidEventMixin
 
     @ModifyArgs(method = "receiveNeighborFluids", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;)Z", ordinal = 1))
     private void basalt$receiveNeighborFluids(Args args, World world, BlockPos pos, BlockState fluidBlockState) {
-        if (basaltReplacement != null) args.set(1, basaltReplacement);
+        if (basaltReplacement != null) {
+            args.set(1, basaltReplacement);
+            basaltReplacement = null;
+        }
     }
 }

--- a/src/main/java/io/github/null2264/cobblegen/mixin/FluidEventMixin.java
+++ b/src/main/java/io/github/null2264/cobblegen/mixin/FluidEventMixin.java
@@ -1,7 +1,7 @@
 package io.github.null2264.cobblegen.mixin;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import io.github.fabricators_of_create.porting_lib.event.common.FluidPlaceBlockCallback;
+import io.github.null2264.cobblegen.compat.porting_lib.FluidInteractionEvent;
 import io.github.null2264.cobblegen.util.BlockGenerator;
 import io.github.null2264.cobblegen.util.GeneratorType;
 import net.fabricmc.loader.api.FabricLoader;
@@ -23,7 +23,7 @@ public abstract class FluidEventMixin
 
     private boolean shouldBasaltGenerate(World world, BlockPos pos, BlockState state, Boolean canGenerate) {
         if (FabricLoader.getInstance().isModLoaded("porting_lib") && canGenerate)
-            basaltReplacement = FluidPlaceBlockCallback.EVENT.invoker().onFluidPlaceBlock(world, pos, state);
+            basaltReplacement = FluidInteractionEvent.invoke(world, pos, state);
 
         if (basaltReplacement == null) {
             BlockGenerator basaltGenerator = new BlockGenerator(world, pos, GeneratorType.BASALT);

--- a/src/main/java/io/github/null2264/cobblegen/mixin/FluidEventMixin.java
+++ b/src/main/java/io/github/null2264/cobblegen/mixin/FluidEventMixin.java
@@ -1,8 +1,10 @@
 package io.github.null2264.cobblegen.mixin;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import io.github.fabricators_of_create.porting_lib.event.common.FluidPlaceBlockCallback;
 import io.github.null2264.cobblegen.util.BlockGenerator;
 import io.github.null2264.cobblegen.util.GeneratorType;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.FluidBlock;
@@ -25,6 +27,10 @@ public abstract class FluidEventMixin
         return basaltReplacement != null;
     }
 
+    /**
+     * Handle fluid interactions (for cobblestone generator).
+     * If Porting Lib is installed, fluid interactions will be handled by {@link io.github.null2264.cobblegen.compat.porting_lib.FluidInteractionEvent}
+     */
     @ModifyArgs(method = "receiveNeighborFluids", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;)Z", ordinal = 0))
     private void cobble$receiveNeighborFluids(
             @NotNull Args args,
@@ -32,6 +38,7 @@ public abstract class FluidEventMixin
             BlockPos pos,
             BlockState fluidBlockState
     ) {
+        if (FabricLoader.getInstance().isModLoaded("porting_lib")) return;
         if (((BlockState) args.get(1)).isOf(Blocks.OBSIDIAN)) return;
 
         BlockGenerator generator = new BlockGenerator(world, pos, GeneratorType.COBBLE);

--- a/src/main/java/io/github/null2264/cobblegen/mixin/LavaEventMixin.java
+++ b/src/main/java/io/github/null2264/cobblegen/mixin/LavaEventMixin.java
@@ -2,6 +2,7 @@ package io.github.null2264.cobblegen.mixin;
 
 import io.github.null2264.cobblegen.util.BlockGenerator;
 import io.github.null2264.cobblegen.util.GeneratorType;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.BlockState;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.LavaFluid;
@@ -17,6 +18,10 @@ import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 @Mixin(LavaFluid.class)
 public class LavaEventMixin
 {
+    /**
+     * Handle fluid interactions (for stone generator).
+     * If Porting Lib is installed, fluid interactions will be handled by {@link io.github.null2264.cobblegen.compat.porting_lib.FluidInteractionEvent}
+     */
     @ModifyArgs(method = "flow", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/WorldAccess;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)Z"))
     private void injected$flow(
             Args args,
@@ -26,6 +31,7 @@ public class LavaEventMixin
             Direction direction,
             FluidState fluidState
     ) {
+        if (FabricLoader.getInstance().isModLoaded("porting_lib")) return;
         BlockGenerator generator = new BlockGenerator((World) world, pos, GeneratorType.STONE);
         generator.tryReplace(args);
     }


### PR DESCRIPTION
Porting Lib is basically doing the exact same thing as CobbleGen to mimic Forge's Fluid Interaction API which causes them to overwrite one another. This causes Create's Limestone and Scoria Generators to be overwritten with CobbleGen's Cobblestone Generator.

Tests:
- [x] With Create/Porting Lib
  - [x] 1.18.2
  - [x] 1.19.2
- [x] Without Create/Porting Lib
  - [x] 1.18.2
  - [x] 1.19.2